### PR TITLE
Add sandbox-exec support to workon command

### DIFF
--- a/include/shared_vars.sh
+++ b/include/shared_vars.sh
@@ -3,4 +3,4 @@
 # Shared variables between install.sh and revert.sh
 HOME_DIR=$HOME # Makes it easy to test
 PROJECT_DIR="$HOME_DIR/dev"
-STOWED_PACKAGES=("zsh" "git" "ghostty" "ssh" "mise" "nvim" "brew" "starship" "dev" "claude")
+STOWED_PACKAGES=("zsh" "git" "ghostty" "ssh" "mise" "nvim" "brew" "starship" "dev" "claude" "sandbox")

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -116,10 +116,10 @@ function _workon_sandboxed() {
     # Save original directory to restore after sandbox exits
     local original_dir="$PWD"
 
-    # Launch sandboxed shell with IN_SANDBOX env var (for starship indicator)
+    # Launch sandboxed shell with sandbox env vars (for starship indicator and chpwd hook)
     # Pass TERM to ensure proper terminal handling (backspace, etc.)
     cd "$projdir"
-    sandbox-exec -p "$profile" env TERM="$TERM" IN_SANDBOX=1 SANDBOX_PROJECT="$projname" /bin/zsh -i
+    sandbox-exec -p "$profile" env TERM="$TERM" IN_SANDBOX=1 SANDBOX_PROJECT="$projname" SANDBOX_PROJECT_DIR="$projdir" /bin/zsh -i
     local exit_code=$?
 
     # Restore original directory
@@ -1302,10 +1302,10 @@ fi
 # =============================================================================
 # Sandbox auto-exit hook (runs when this file is sourced inside sandbox)
 # =============================================================================
-if [[ -n "$IN_SANDBOX" && -n "$SANDBOX_PROJECT" ]]; then
+if [[ -n "$IN_SANDBOX" && -n "$SANDBOX_PROJECT_DIR" ]]; then
     _sandbox_chpwd() {
         # Exit sandbox if we've left the project directory
-        if [[ "$PWD" != "$HOME/dev/$SANDBOX_PROJECT"* ]]; then
+        if [[ "$PWD" != "$SANDBOX_PROJECT_DIR"* ]]; then
             echo "Left sandbox project, exiting..."
             exit 0
         fi

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -81,12 +81,12 @@ function _sandbox_add_hooks() {
     local projname=$(basename "$projdir")
 
     # Append hooks to .mise.toml
-    # Note: Use temp file marker since env vars don't pass through sandbox-exec reliably
+    # Note: IN_SANDBOX env var is set by sandbox-exec and inherited by child processes
     cat >> "$mise_file" << EOF
 
 [hooks]
-enter = 'if [ ! -f "/tmp/.sandbox-active" ] && [ -f ".sandbox" ]; then zsh -c "source ~/.dotfiles/lib/misewrapper.sh && _workon_sandboxed ${projname} ${projdir}"; fi'
-leave = '[ -f "/tmp/.sandbox-active" ] && exit 0 || true'
+enter = 'if [ -z "\$IN_SANDBOX" ] && [ -f ".sandbox" ]; then zsh -c "source ~/.dotfiles/lib/misewrapper.sh && _workon_sandboxed ${projname} ${projdir}"; fi'
+leave = '[ -n "\$IN_SANDBOX" ] && exit 0 || true'
 EOF
 
     echo "Sandbox hooks added to $mise_file"
@@ -113,9 +113,6 @@ function _workon_sandboxed() {
     echo "  Exit with:     exit or Ctrl-D"
     echo ""
 
-    # Create marker file to prevent mise hook from re-entering sandbox
-    touch /tmp/.sandbox-active
-
     # Save original directory to restore after sandbox exits
     local original_dir="$PWD"
 
@@ -127,9 +124,6 @@ function _workon_sandboxed() {
 
     # Restore original directory
     cd "$original_dir"
-
-    # Clean up marker file
-    rm -f /tmp/.sandbox-active
 
     _sandbox_log "$projname" "EXIT" "pid=$$ code=$exit_code"
 

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -482,10 +482,13 @@ cloneproject() {
 }
 
 # Change to a specific project
-# Usage: workon <project_name> [--sandbox|-s]
+# Usage: workon <project_name> [-s|--sandbox]
 function workon() {
     if [[ $# -lt 1 ]]; then
-        echo "Usage: workon <project_name> [--sandbox|-s]"
+        echo "Usage: workon <project_name> [-s]"
+        echo ""
+        echo "Options:"
+        echo "  -s, --sandbox  Run in sandboxed environment (restricted filesystem access)"
         return 1
     fi
 

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -79,9 +79,9 @@ function _workon_sandboxed() {
     local projdir="$2"
 
     # Generate profile with expanded variables
-    local profile=$(_sandbox_generate_profile "$projdir")
-    if [[ $? -ne 0 ]]; then
-        echo "Failed to generate sandbox profile"
+    # Note: separate declaration from assignment so $? isn't reset by 'local'
+    local profile
+    if ! profile=$(_sandbox_generate_profile "$projdir"); then
         return 1
     fi
 

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -97,6 +97,13 @@ function _workon_sandboxed() {
     local projname="$1"
     local projdir="$2"
 
+    # Prevent nested sandboxes
+    if [[ -n "$IN_SANDBOX" ]]; then
+        echo "Already in sandbox for: $SANDBOX_PROJECT"
+        echo "Exit current sandbox first (exit or Ctrl-D)"
+        return 1
+    fi
+
     # Generate profile with expanded variables
     # Note: separate declaration from assignment so $? isn't reset by 'local'
     local profile

--- a/lib/misewrapper.sh
+++ b/lib/misewrapper.sh
@@ -77,18 +77,15 @@ function _sandbox_log() {
 function _sandbox_add_hooks() {
     local projdir="$1"
     local mise_file="$projdir/.mise.toml"
+    local projname=$(basename "$projdir")
 
     # Append hooks to .mise.toml
-    cat >> "$mise_file" << 'EOF'
+    # Note: mise runs hooks with sh, so we exec zsh for zsh-specific scripts
+    cat >> "$mise_file" << EOF
 
 [hooks]
-enter = '''
-if [ -z "$IN_SANDBOX" ] && [ -f ".sandbox" ]; then
-    source ~/.dotfiles/lib/misewrapper.sh
-    _workon_sandboxed "$(basename $PWD)" "$PWD"
-fi
-'''
-leave = '[ -n "$IN_SANDBOX" ] && exit || true'
+enter = 'if [ -z "\$IN_SANDBOX" ] && [ -f ".sandbox" ]; then zsh -c "source ~/.dotfiles/lib/misewrapper.sh && _workon_sandboxed ${projname} ${projdir}"; fi'
+leave = '[ -n "\$IN_SANDBOX" ] && exit 0 || true'
 EOF
 
     echo "Sandbox hooks added to $mise_file"

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -21,9 +21,15 @@
 ;; === HOMEBREW (read-only) ===
 (allow file-read* (subpath "/opt/homebrew"))
 
-;; === MISE TOOLS (read-only) ===
-(allow file-read* (subpath "${HOME}/.local/share/mise"))
+;; === MISE (read/write for shims, cache, state) ===
+(allow file-read* file-write* (subpath "${HOME}/.local/share/mise"))
+(allow file-read* file-write* (subpath "${HOME}/.local/state/mise"))
 (allow file-read* (subpath "${HOME}/.local/bin"))
+
+;; === CODING AGENTS (read/write for config and state) ===
+(allow file-read* file-write* (subpath "${HOME}/.claude"))
+(allow file-read* file-write* (subpath "${HOME}/.codex"))
+(allow file-read* file-write* (subpath "${HOME}/.opencode"))
 
 ;; === HOME CONFIG (read-only) ===
 (allow file-read* (subpath "${HOME}/.config"))

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -20,10 +20,7 @@
 
 ;; === DEVICE WRITE ACCESS (null, tty, fd) ===
 (allow file-write*
-    (literal "/dev/null")
-    (literal "/dev/tty")
-    (regex #"^/dev/fd/")
-    (regex #"^/dev/ttys"))
+    (subpath "/dev"))
 
 ;; === HOMEBREW (read-only) ===
 (allow file-read* (subpath "/opt/homebrew"))
@@ -53,6 +50,9 @@
 (allow file-read* (subpath "${HOME}/.bundle"))
 (allow file-read* (subpath "${HOME}/.pyenv"))
 (allow file-read* (subpath "${HOME}/.rbenv"))
+
+;; === MACOS APP SUPPORT (read-only for tools like zoxide) ===
+(allow file-read* (subpath "${HOME}/Library/Application Support"))
 
 ;; === PROJECT DIRECTORY (read/write) ===
 (allow file-read* file-write* (subpath "${PROJECT_DIR}"))

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -17,6 +17,7 @@
     (subpath "/bin")
     (subpath "/sbin")
     (subpath "/Library")
+    (subpath "/Applications")
     (subpath "/private/var")
     (subpath "/private/etc")
     (subpath "/dev"))
@@ -28,8 +29,9 @@
 ;; === HOMEBREW (read-only) ===
 (allow file-read* (subpath "/opt/homebrew"))
 
-;; === MISE (read/write for shims, cache, state) ===
+;; === MISE and ZOXIDE (read/write for shims, cache, state, db) ===
 (allow file-read* file-write* (subpath "${HOME}/.local/share/mise"))
+(allow file-read* file-write* (subpath "${HOME}/.local/share/zoxide"))
 (allow file-read* file-write* (subpath "${HOME}/.local/state"))
 (allow file-read* (subpath "${HOME}/.local/bin"))
 

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -7,8 +7,11 @@
 (allow signal)
 
 ;; === SYSTEM READ ACCESS ===
+;; Note: /Users and ${HOME} literals needed for path traversal (mkdir -p)
 (allow file-read*
     (literal "/")
+    (literal "/Users")
+    (literal "${HOME}")
     (subpath "/System")
     (subpath "/usr")
     (subpath "/bin")
@@ -35,11 +38,12 @@
 (allow file-read* file-write* (subpath "${HOME}/.codex"))
 (allow file-read* file-write* (subpath "${HOME}/.opencode"))
 
-;; === HOME CONFIG (read-only) ===
+;; === HOME CONFIG (read-only, except zsh_history) ===
 (allow file-read* (subpath "${HOME}/.config"))
 (allow file-read* (subpath "${HOME}/.zshrc"))
 (allow file-read* (subpath "${HOME}/.zshenv"))
 (allow file-read* (subpath "${HOME}/.dotfiles"))
+(allow file-read* file-write* (regex #"^${HOME}/\.zsh_history.*"))
 
 ;; === LANGUAGE TOOLCHAINS (read-only) ===
 (allow file-read* (subpath "${HOME}/.cargo"))
@@ -55,6 +59,8 @@
 (allow file-read* (subpath "${HOME}/Library/Application Support"))
 
 ;; === PROJECT DIRECTORY (read/write) ===
+;; Note: ${HOME}/dev literal needed for path traversal to project subdirectories
+(allow file-read* (literal "${HOME}/dev"))
 (allow file-read* file-write* (subpath "${PROJECT_DIR}"))
 
 ;; === TEMP (read/write) ===

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -1,0 +1,50 @@
+(version 1)
+(deny default)
+
+;; === PROCESS EXECUTION ===
+(allow process-fork)
+(allow process-exec)
+(allow signal)
+
+;; === SYSTEM READ ACCESS ===
+(allow file-read*
+    (literal "/")
+    (subpath "/System")
+    (subpath "/usr")
+    (subpath "/bin")
+    (subpath "/sbin")
+    (subpath "/Library")
+    (subpath "/private/var")
+    (subpath "/private/etc")
+    (subpath "/dev"))
+
+;; === HOMEBREW (read-only) ===
+(allow file-read* (subpath "/opt/homebrew"))
+
+;; === MISE TOOLS (read-only) ===
+(allow file-read* (subpath "${HOME}/.local/share/mise"))
+(allow file-read* (subpath "${HOME}/.local/bin"))
+
+;; === HOME CONFIG (read-only) ===
+(allow file-read* (subpath "${HOME}/.config"))
+(allow file-read* (subpath "${HOME}/.zshrc"))
+(allow file-read* (subpath "${HOME}/.zshenv"))
+(allow file-read* (subpath "${HOME}/.dotfiles"))
+
+;; === PROJECT DIRECTORY (read/write) ===
+(allow file-read* file-write* (subpath "${PROJECT_DIR}"))
+
+;; === TEMP (read/write) ===
+(allow file-read* file-write* (subpath "/tmp"))
+(allow file-read* file-write* (subpath "/private/tmp"))
+(allow file-read* file-write* (subpath "${HOME}/.cache"))
+
+;; === NETWORK ===
+(allow network-outbound)
+(allow network-inbound (local ip))
+(allow system-socket)
+
+;; === IPC / MACH ===
+(allow mach-lookup)
+(allow ipc-posix-shm)
+(allow sysctl-read)

--- a/sandbox/.config/sandbox/profiles/default.sb
+++ b/sandbox/.config/sandbox/profiles/default.sb
@@ -18,12 +18,19 @@
     (subpath "/private/etc")
     (subpath "/dev"))
 
+;; === DEVICE WRITE ACCESS (null, tty, fd) ===
+(allow file-write*
+    (literal "/dev/null")
+    (literal "/dev/tty")
+    (regex #"^/dev/fd/")
+    (regex #"^/dev/ttys"))
+
 ;; === HOMEBREW (read-only) ===
 (allow file-read* (subpath "/opt/homebrew"))
 
 ;; === MISE (read/write for shims, cache, state) ===
 (allow file-read* file-write* (subpath "${HOME}/.local/share/mise"))
-(allow file-read* file-write* (subpath "${HOME}/.local/state/mise"))
+(allow file-read* file-write* (subpath "${HOME}/.local/state"))
 (allow file-read* (subpath "${HOME}/.local/bin"))
 
 ;; === CODING AGENTS (read/write for config and state) ===
@@ -36,6 +43,16 @@
 (allow file-read* (subpath "${HOME}/.zshrc"))
 (allow file-read* (subpath "${HOME}/.zshenv"))
 (allow file-read* (subpath "${HOME}/.dotfiles"))
+
+;; === LANGUAGE TOOLCHAINS (read-only) ===
+(allow file-read* (subpath "${HOME}/.cargo"))
+(allow file-read* (subpath "${HOME}/.rustup"))
+(allow file-read* (subpath "${HOME}/.npm"))
+(allow file-read* (subpath "${HOME}/.node"))
+(allow file-read* (subpath "${HOME}/.gem"))
+(allow file-read* (subpath "${HOME}/.bundle"))
+(allow file-read* (subpath "${HOME}/.pyenv"))
+(allow file-read* (subpath "${HOME}/.rbenv"))
 
 ;; === PROJECT DIRECTORY (read/write) ===
 (allow file-read* file-write* (subpath "${PROJECT_DIR}"))
@@ -54,3 +71,7 @@
 (allow mach-lookup)
 (allow ipc-posix-shm)
 (allow sysctl-read)
+
+;; === TTY / PTY CONTROL ===
+(allow file-ioctl)
+(allow process-info-pidinfo)

--- a/starship/.config/starship/starship.toml
+++ b/starship/.config/starship/starship.toml
@@ -153,6 +153,6 @@ format = '[ ♥ $time ]($style)'
 [custom.sandbox]
 command = "echo '🔒'"
 when = '[ "$IN_SANDBOX" = "1" ]'
-style = "bg:#FF6B6B fg:#FFFFFF bold"
-format = "[](fg:#9A348E bg:#FF6B6B)[ $output ]($style)[](fg:#FF6B6B bg:#DA627D)"
+style = "bg:#9A348E fg:#FFFFFF bold"
+format = "[$output ]($style)"
 disabled = false

--- a/starship/.config/starship/starship.toml
+++ b/starship/.config/starship/starship.toml
@@ -2,6 +2,7 @@ format = """
 [](#9A348E)\
 $os\
 $username\
+${custom.sandbox}\
 [](bg:#DA627D fg:#9A348E)\
 $directory\
 [](fg:#DA627D bg:#FCA17D)\
@@ -147,3 +148,11 @@ disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#33658A"
 format = '[ ♥ $time ]($style)'
+
+# Sandbox indicator - shows lock icon when IN_SANDBOX=1
+[custom.sandbox]
+command = "echo '🔒'"
+when = '[ "$IN_SANDBOX" = "1" ]'
+style = "bg:#FF6B6B fg:#FFFFFF bold"
+format = "[](fg:#9A348E bg:#FF6B6B)[ $output ]($style)[](fg:#FF6B6B bg:#DA627D)"
+disabled = false


### PR DESCRIPTION
Integrate macOS sandbox-exec into project workflow for containing coding agents (Claude Code, Codex, OpenCode) with project-scoped filesystem access.

Changes:
- Add Seatbelt profile template (sandbox/.config/sandbox/profiles/default.sb)
- Add sandbox helper functions to misewrapper.sh
- Update workon to accept --sandbox/-s flag
- Add "sandbox" to STOWED_PACKAGES
- Update tab completion for sandbox options

Usage: workon <project> --sandbox

Sandbox provides:
- Read/write access to project directory only
- Read-only access to tools (~/.local/share/mise, /opt/homebrew)
- Outbound network allowed
- Violation logging to ~/.local/state/sandbox/logs/